### PR TITLE
Add network uplink interface parameter to the VRS puppet module for c…

### DIFF
--- a/modules/nuage/manifests/vrs.pp
+++ b/modules/nuage/manifests/vrs.pp
@@ -18,6 +18,7 @@
 class nuage::vrs (
   $active_controller,
   $standby_controller = undef,
+  $network_uplink_intf = undef,
   $package_ensure    = 'present',
 ) {
 
@@ -43,6 +44,17 @@ class nuage::vrs (
       ensure  => present,
       line    => "STANDBY_CONTROLLER=${standby_controller}",
       match   => 'STANDBY_CONTROLLER=',
+      path    => '/etc/default/openvswitch',
+      notify  => Service[$nuage::params::nuage_vrs_service],
+      require => Package[$nuage::params::nuage_vrs_package],
+    }
+  }
+
+  if $network_uplink_intf != undef {
+    file_line { 'openvswitch network uplink interface':
+      ensure  => present,
+      line    => "NETWORK_UPLINK_INTF=${network_uplink_intf}",
+      match   => 'NETWORK_UPLINK_INTF=',
       path    => '/etc/default/openvswitch',
       notify  => Service[$nuage::params::nuage_vrs_service],
       require => Package[$nuage::params::nuage_vrs_package],


### PR DESCRIPTION
…onfiguring OVS to uplink for external/floating IP routing

network_uplink_intf parameter undefined by default just like secondary controller

See [1] for more info

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1342538
